### PR TITLE
support different configurations based on the weight file name

### DIFF
--- a/convert_onnx.py
+++ b/convert_onnx.py
@@ -1,11 +1,24 @@
 import torch
 import os
+from config import set_cfg
 from yolact_edge.yolact import Yolact
+import re
+
+
+def set_cfg_from_pth(file_name):
+    file_name = file_name.split('/')[-1]
+
+    split_regex = '(_[\d_]*)?\.pth'
+    matches = re.split(split_regex, file_name)
+
+    set_cfg(matches[0] + '_config')
+
 
 if __name__=='__main__':
     device = 'cpu'
     # trained_model = 'weights/yolact_edge_resnet50_54_800000.pth'
     trained_model = 'weights/yolact_edge_mobilenetv2_54_800000.pth'
+    set_cfg_from_pth(trained_model)
     net = Yolact()
     net.load_weights(trained_model)
     net.eval()

--- a/convert_onnx.py
+++ b/convert_onnx.py
@@ -8,7 +8,7 @@ import re
 def set_cfg_from_pth(file_name):
     file_name = file_name.split('/')[-1]
 
-    split_regex = '(_[\d_]*)?\.pth'
+    split_regex = '(_[\d_]*)?(_interrupt)?\.pth'
     matches = re.split(split_regex, file_name)
 
     set_cfg(matches[0] + '_config')


### PR DESCRIPTION
With this pull request the correct configuration is loaded. The configuration name is automatically inferred based on the name of the model file. 

The automatic configuration works at least with the downloadable yolact_edge models that are provided in the original yolact_edge repository. 
